### PR TITLE
Bump gson to 2.8.9 for vulnerability fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 dependencies {
     implementation group: "com.squareup.okhttp3", name: "okhttp", version:"3.9.1"
     implementation group: "org.slf4j", name: "slf4j-api", version:"1.7.25"
-    implementation group: "com.google.code.gson", name: "gson", version:"2.8.2"
+    implementation group: "com.google.code.gson", name: "gson", version:"2.8.9"
     implementation group: "commons-codec", name: "commons-codec", version:"1.13"
     implementation "net.sourceforge.streamsupport:android-retrofuture:1.7.0"
     implementation 'de.skuzzle:semantic-version:2.1.0'


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR updates the `gson` dependency to `2.8.9` where the reported CWE-502 security issue was fixed.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
