### PR TITLE
Make SettingType enum public and use it as Setting's type field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     testImplementation group: "org.junit.jupiter", name: "junit-jupiter-params", version:"5.8.0"
     testImplementation group: "org.slf4j", name: "slf4j-nop", version:"1.7.25"
     testImplementation group: "com.squareup.okhttp3", name: "mockwebserver", version:"4.10.0"
-    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-core:4.7.0'
     testImplementation 'net.sourceforge.streamsupport:android-retrofuture:1.7.4'
     testRuntimeOnly group: "org.junit.jupiter", name: "junit-jupiter-engine", version:"5.8.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=7.1.0
+version=7.2.0
 
 org.gradle.jvmargs=-Xmx2g

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion 32
     defaultConfig {
         applicationId "com.configcat.configcatsample"
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 32
         versionCode 1
         versionName "1.0"
@@ -36,7 +36,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10'
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'com.configcat:configcat-android-client:7.1.0'
+    implementation 'com.configcat:configcat-android-client:7.2.0'
     implementation 'org.slf4j:slf4j-android:1.+'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/src/main/java/com/configcat/ConfigCatClient.java
+++ b/src/main/java/com/configcat/ConfigCatClient.java
@@ -458,14 +458,14 @@ public final class ConfigCatClient implements ConfigurationProvider {
             throw new IllegalArgumentException("Only String, Integer, Double or Boolean types are supported");
     }
 
-    private Class<?> classBySettingType(int settingType) {
-        if (settingType == SettingType.BOOLEAN.ordinal())
+    private Class<?> classBySettingType(SettingType settingType) {
+        if (settingType == SettingType.BOOLEAN)
             return boolean.class;
-        else if (settingType == SettingType.STRING.ordinal())
+        else if (settingType == SettingType.STRING)
             return String.class;
-        else if (settingType == SettingType.INT.ordinal())
+        else if (settingType == SettingType.INT)
             return int.class;
-        else if (settingType == SettingType.DOUBLE.ordinal())
+        else if (settingType == SettingType.DOUBLE)
             return double.class;
         else
             throw new IllegalArgumentException("Only String, Integer, Double or Boolean types are supported");

--- a/src/main/java/com/configcat/ConfigModels.java
+++ b/src/main/java/com/configcat/ConfigModels.java
@@ -5,13 +5,6 @@ import com.google.gson.annotations.SerializedName;
 import java.util.HashMap;
 import java.util.Map;
 
-enum SettingType {
-    BOOLEAN,
-    STRING,
-    INT,
-    DOUBLE,
-}
-
 class Config {
     @SerializedName(value = "p")
     public Preferences preferences;

--- a/src/main/java/com/configcat/LocalMapDataSource.java
+++ b/src/main/java/com/configcat/LocalMapDataSource.java
@@ -17,6 +17,7 @@ class LocalMapDataSource extends OverrideDataSource {
         for (Map.Entry<String, Object> entry : source.entrySet()) {
             Setting setting = new Setting();
             setting.value = gson.toJsonTree(entry.getValue());
+            setting.type = determineSettingType(entry.getValue());
             this.loadedSettings.put(entry.getKey(), setting);
         }
     }
@@ -24,5 +25,19 @@ class LocalMapDataSource extends OverrideDataSource {
     @Override
     public Map<String, Setting> getLocalConfiguration() {
         return this.loadedSettings;
+    }
+
+    private SettingType determineSettingType(Object value) {
+        if (value instanceof String) {
+            return SettingType.STRING;
+        } else if (value instanceof Boolean) {
+            return SettingType.BOOLEAN;
+        } else if (value instanceof Integer) {
+            return SettingType.INT;
+        } else if (value instanceof Double) {
+            return SettingType.DOUBLE;
+        } else {
+            throw new IllegalArgumentException("Could not determine the setting type of '"+value+"'");
+        }
     }
 }

--- a/src/main/java/com/configcat/Setting.java
+++ b/src/main/java/com/configcat/Setting.java
@@ -15,14 +15,9 @@ public class Setting {
 
     /**
      * Type of the feature flag / setting.
-     *
-     * 0: [bool],
-     * 1: [String],
-     * 2: [int],
-     * 3: [double],
      */
     @SerializedName(value = "t")
-    public int type;
+    public SettingType type;
 
     /**
      * Collection of percentage rules that belongs to the feature flag / setting.

--- a/src/main/java/com/configcat/SettingType.java
+++ b/src/main/java/com/configcat/SettingType.java
@@ -1,0 +1,24 @@
+package com.configcat;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Describes the type of ConfigCat Feature Flag / Setting
+ */
+public enum SettingType {
+    /** Represents a feature flag. */
+    @SerializedName("0")
+    BOOLEAN,
+
+    /** Represents a string setting. */
+    @SerializedName("1")
+    STRING,
+
+    /** Represents a whole number setting. */
+    @SerializedName("2")
+    INT,
+
+    /** Represents a decimal number setting. */
+    @SerializedName("3")
+    DOUBLE,
+}

--- a/src/test/java/com/configcat/ConfigCatClientTest.java
+++ b/src/test/java/com/configcat/ConfigCatClientTest.java
@@ -21,8 +21,8 @@ class ConfigCatClientTest {
 
     private static final String APIKEY = "TEST_KEY";
 
-    private static final String TEST_JSON = "{ f: { fakeKey: { v: fakeValue, s: 0, p: [] ,r: [] } } }";
-    private static final String TEST_JSON_MULTIPLE = "{ f: { key1: { v: true, i: 'fakeId1', p: [] ,r: [] }, key2: { v: false, i: 'fakeId2', p: [] ,r: [] } } }";
+    private static final String TEST_JSON = "{ f: { fakeKey: { v: fakeValue, t: 0, p: [] ,r: [] } } }";
+    private static final String TEST_JSON_MULTIPLE = "{ f: { key1: { v: true, t: 0, i: 'fakeId1', p: [] ,r: [] }, key2: { v: false, t: 0, i: 'fakeId2', p: [] ,r: [] } } }";
 
     @Test
     void ensuresApiKeyIsNotNull() {


### PR DESCRIPTION
### Describe the purpose of your pull request

Make `SettingType` enum public and use it in `Setting` as the type of the `type` field.

### Related issues (only if applicable)

#19 

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
