### PR TITLE
Fix auto poll initial config load from cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=10.1.1
+version=10.1.2
 
 org.gradle.jvmargs=-Xmx2g

--- a/src/main/java/com/configcat/ConfigService.java
+++ b/src/main/java/com/configcat/ConfigService.java
@@ -103,7 +103,12 @@ class ConfigService implements Closeable {
                             ? new SettingResult(entryResult.value().getConfig().getEntries(), entryResult.value().getFetchTime())
                             : SettingResult.EMPTY);
         } else {
-            return fetchIfOlder(Constants.DISTANT_PAST, initialized.get()) // If we are initialized, we prefer the cached results
+            long threshold = Constants.DISTANT_PAST;
+            if (!initialized.get() && mode instanceof AutoPollingMode) {
+                AutoPollingMode autoPollingMode = (AutoPollingMode) mode;
+                threshold = System.currentTimeMillis() - (autoPollingMode.getAutoPollRateInSeconds() * 1000L);
+            }
+            return fetchIfOlder(threshold, initialized.get()) // If we are initialized, we prefer the cached results
                     .thenApply(entryResult -> !entryResult.value().isEmpty()
                             ? new SettingResult(entryResult.value().getConfig().getEntries(), entryResult.value().getFetchTime())
                             : SettingResult.EMPTY);

--- a/src/main/java/com/configcat/Utils.java
+++ b/src/main/java/com/configcat/Utils.java
@@ -30,7 +30,7 @@ final class Constants {
     static final long DISTANT_PAST = 0;
     static final String CONFIG_JSON_NAME = "config_v6.json";
     static final String SERIALIZATION_FORMAT_VERSION = "v2";
-    static final String VERSION = "10.1.1";
+    static final String VERSION = "10.1.2";
 
     static final String SDK_KEY_PROXY_PREFIX = "configcat-proxy/";
     static final String SDK_KEY_PREFIX = "configcat-sdk-1";


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fix initial config JSON load when auto poll enabled with results from cache.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
