### PR TITLE
Hooks update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=10.1.2
+version=10.2.0
 
 org.gradle.jvmargs=-Xmx2g

--- a/src/main/java/com/configcat/ClientCacheState.java
+++ b/src/main/java/com/configcat/ClientCacheState.java
@@ -1,0 +1,23 @@
+package com.configcat;
+
+/**
+ * Describes the Client state.
+ */
+public enum ClientCacheState {
+    /**
+     *  The SDK has no feature flag data neither from the cache nor from the ConfigCat CDN.
+     */
+    NO_FLAG_DATA,
+    /**
+     * The SDK runs with local only feature flag data.
+     */
+    HAS_LOCAL_OVERRIDE_FLAG_DATA_ONLY,
+    /**
+     * The SDK has feature flag data to work with only from the cache.
+     */
+    HAS_CACHED_FLAG_DATA_ONLY,
+    /**
+     * The SDK works with the latest feature flag data received from the ConfigCat CDN.
+     */
+    HAS_UP_TO_DATE_FLAG_DATA,
+}

--- a/src/main/java/com/configcat/ConfigCatHooks.java
+++ b/src/main/java/com/configcat/ConfigCatHooks.java
@@ -12,8 +12,8 @@ public class ConfigCatHooks {
     private final AtomicReference<ClientCacheState> clientCacheState = new AtomicReference<>(null);
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
     private final List<Consumer<Map<String, Setting>>> onConfigChanged = new ArrayList<>();
-    private final List<Consumer<ClientCacheState>> onClientReady = new ArrayList<>();
-    private final List<Consumer<EvaluationDetails<Object>>> onFlagEvaluated = new ArrayList<>();
+    private final List<Consumer<ClientCacheState>> onClientReadyWithState = new ArrayList<>();
+    private final List<Runnable> onClientReady = new ArrayList<>();    private final List<Consumer<EvaluationDetails<Object>>> onFlagEvaluated = new ArrayList<>();
     private final List<Consumer<String>> onError = new ArrayList<>();
 
     /**
@@ -31,8 +31,27 @@ public class ConfigCatHooks {
             if(clientCacheState.get() != null) {
                 callback.accept(clientCacheState.get());
             } else {
-                this.onClientReady.add(callback);
+                this.onClientReadyWithState.add(callback);
             }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Subscribes to the onReady event. This event is fired when the SDK reaches the ready state.
+     * If the SDK is configured with lazy load or manual polling it's considered ready right after instantiation.
+     * In case of auto polling, the ready state is reached when the SDK has a valid config.json loaded
+     * into memory either from cache or from HTTP. If the config couldn't be loaded neither from cache nor from HTTP the
+     * onReady event fires when the auto polling's maxInitWaitTimeInSeconds is reached.
+     *
+     * @param callback the method to call when the event fires.
+     */
+    @Deprecated
+    public void addOnClientReady(Runnable callback) {
+        lock.writeLock().lock();
+        try {
+            this.onClientReady.add(callback);
         } finally {
             lock.writeLock().unlock();
         }
@@ -86,8 +105,11 @@ public class ConfigCatHooks {
         lock.readLock().lock();
         try {
             this.clientCacheState.set(clientCacheState);
-            for (Consumer<ClientCacheState> func : this.onClientReady) {
+            for (Consumer<ClientCacheState> func : this.onClientReadyWithState) {
                 func.accept(clientCacheState);
+            }
+            for (Runnable func : this.onClientReady) {
+                func.run();
             }
         } finally {
             lock.readLock().unlock();

--- a/src/main/java/com/configcat/ConfigurationProvider.java
+++ b/src/main/java/com/configcat/ConfigurationProvider.java
@@ -255,4 +255,11 @@ public interface ConfigurationProvider extends Closeable {
      * @return True if the client is closed.
      */
     boolean isClosed();
+
+    /**
+     * Awaits for SDK initialization.
+     *
+     * @return the future which executes the wait for ready and return with the client state.
+     */
+    CompletableFuture<ClientCacheState> waitForReadyAsync();
 }

--- a/src/main/java/com/configcat/Entry.java
+++ b/src/main/java/com/configcat/Entry.java
@@ -37,6 +37,10 @@ public class Entry {
         return EMPTY.equals(this);
     }
 
+    public boolean isExpired(long threshold) {
+        return fetchTime <= threshold ;
+    }
+
     public static final Entry EMPTY = new Entry(Config.EMPTY, "", "", Constants.DISTANT_PAST);
 
     public String serialize() {

--- a/src/main/java/com/configcat/Utils.java
+++ b/src/main/java/com/configcat/Utils.java
@@ -30,7 +30,7 @@ final class Constants {
     static final long DISTANT_PAST = 0;
     static final String CONFIG_JSON_NAME = "config_v6.json";
     static final String SERIALIZATION_FORMAT_VERSION = "v2";
-    static final String VERSION = "10.1.2";
+    static final String VERSION = "10.2.0";
 
     static final String SDK_KEY_PROXY_PREFIX = "configcat-proxy/";
     static final String SDK_KEY_PREFIX = "configcat-sdk-1";

--- a/src/test/java/com/configcat/Helpers.java
+++ b/src/test/java/com/configcat/Helpers.java
@@ -44,6 +44,17 @@ final class Helpers {
         }
     }
 
+    static void waitForClientCacheState(long timeout, Supplier<ClientCacheState> predicate) throws InterruptedException {
+        long end = System.currentTimeMillis() + timeout;
+        while (predicate.get() == null) {
+            Thread.sleep(200);
+            if (System.currentTimeMillis() > end) {
+                throw new RuntimeException("Test timed out.");
+            }
+        }
+    }
+
+
     public static String readFile(String filePath) throws IOException {
 
         try (InputStream stream = Helpers.class.getClassLoader().getResourceAsStream(filePath)) {


### PR DESCRIPTION
### Describe the purpose of your pull request

- Replace sync with `ReentrantReadWriteLock` in `ConfigCatHooks`
- Deprecated `addClientOnReady` and added new `addClientOnReady(ClientCacheState)`
- Added `waitForReadyAsync` method to client
- Prepare to release 10.2.0

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
