### PR TITLE
Accept only 200 HTTP status code / check for empty response body / error log extended with exception.getMessage

### DIFF
--- a/src/main/java/com/configcat/Config.java
+++ b/src/main/java/com/configcat/Config.java
@@ -13,7 +13,7 @@ public class Config {
     @SerializedName(value = "p")
     private Preferences preferences;
     @SerializedName(value = "f")
-    private final Map<String, Setting> entries = new HashMap<>();
+    private Map<String, Setting> entries = new HashMap<>();
     @SerializedName(value = "s")
     private Segment[] segments;
 
@@ -35,7 +35,9 @@ public class Config {
      * The map of settings.
      */
     public Map<String, Setting> getEntries() {
-        return entries;
+        // NOTE: Deserializing a JSON like '{ "f": null }' overwrites entries with null.
+        // However, we want to treat null as an empty map in that case too.
+        return entries != null ? entries : (entries = new HashMap<>());
     }
 
     boolean isEmpty() {

--- a/src/main/java/com/configcat/ConfigCatLogger.java
+++ b/src/main/java/com/configcat/ConfigCatLogger.java
@@ -45,7 +45,7 @@ class ConfigCatLogger {
     public void error(int eventId, Object message, Throwable exception) {
         if (this.hooks != null) this.hooks.invokeOnError(message);
         if (filter(eventId,  LogLevel.ERROR, message, exception)) {
-            this.logger.error("[{}] {}", eventId, message, exception);
+            this.logger.error("[{}] {} {}", eventId, message, exception.getMessage(), exception);
         }
     }
 

--- a/src/main/java/com/configcat/ConfigFetcher.java
+++ b/src/main/java/com/configcat/ConfigFetcher.java
@@ -174,8 +174,8 @@ class ConfigFetcher implements Closeable {
             public void onResponse(@NotNull Call call, @NotNull Response response) {
                 try (ResponseBody body = response.body()) {
                     String cfRayId = response.header("CF-RAY");
-                    if (response.isSuccessful() && body != null) {
-                        String content = body.string();
+                    if (response.code() == 200) {
+                        String content = body != null ? body.string() : null;
                         String eTag = response.header("ETag");
                         Result<Config> result = deserializeConfig(content, cfRayId);
                         if (result.error() != null) {
@@ -192,7 +192,8 @@ class ConfigFetcher implements Closeable {
                         }
                         future.complete(FetchResponse.notModified(cfRayId));
                     } else if (response.code() == 403 || response.code() == 404) {
-                        FormattableLogMessage message = ConfigCatLogMessages.getFetchFailedDueToInvalidSDKKey(cfRayId);                        logger.error(1100, message);
+                        FormattableLogMessage message = ConfigCatLogMessages.getFetchFailedDueToInvalidSDKKey(cfRayId);
+                        logger.error(1100, message);
                         future.complete(FetchResponse.failed(message, true, cfRayId));
                     } else {
                         FormattableLogMessage message = ConfigCatLogMessages.getFetchFailedDueToUnexpectedHttpResponse(response.code(), response.message(), cfRayId);

--- a/src/main/java/com/configcat/RolloutEvaluator.java
+++ b/src/main/java/com/configcat/RolloutEvaluator.java
@@ -58,7 +58,7 @@ class RolloutEvaluator {
 
     private EvaluationResult evaluateSetting(Setting setting, EvaluateLogger evaluateLogger, EvaluationContext context) {
         EvaluationResult evaluationResult = null;
-        if (setting.getTargetingRules() != null) {
+        if (setting.getTargetingRules() != null  && setting.getTargetingRules().length > 0) {
             evaluationResult = evaluateTargetingRules(setting, context, evaluateLogger);
         }
         if (evaluationResult == null && setting.getPercentageOptions() != null && setting.getPercentageOptions().length > 0) {

--- a/src/main/java/com/configcat/Utils.java
+++ b/src/main/java/com/configcat/Utils.java
@@ -11,8 +11,16 @@ final class Utils {
     static final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
     public static Config deserializeConfig(String json) {
+        if (json == null || json.isEmpty()) {
+            throw new IllegalArgumentException("Config JSON content cannot be null or empty.");
+        }
         Config config = Utils.gson.fromJson(json, Config.class);
-        String salt = config.getPreferences().getSalt();
+
+        if (config == null) {
+            throw new IllegalArgumentException("Invalid config JSON content: " + json);
+        }
+
+        String salt = config.getPreferences() != null ? config.getPreferences().getSalt() : null;
         Segment[] segments = config.getSegments();
         if (segments == null) {
             segments = new Segment[]{};

--- a/src/test/java/com/configcat/ConfigFetcherTest.java
+++ b/src/test/java/com/configcat/ConfigFetcherTest.java
@@ -259,7 +259,7 @@ class ConfigFetcherTest {
         assertTrue(response.isFailed());
         assertTrue(response.error().toString().contains("(Ray ID: 12345)"));
 
-        verify(mockLogger, times(1)).error(anyString(), eq(1105), eq(ConfigCatLogMessages.getFetchReceived200WithInvalidBodyError("12345")), any(Exception.class));
+        verify(mockLogger, times(1)).error(anyString(), eq(1105), eq(ConfigCatLogMessages.getFetchReceived200WithInvalidBodyError("12345")), any(), any(Exception.class));
 
         fetcher.close();
     }

--- a/src/test/java/com/configcat/ConfigFetcherTest.java
+++ b/src/test/java/com/configcat/ConfigFetcherTest.java
@@ -8,12 +8,16 @@ import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -136,6 +140,32 @@ class ConfigFetcherTest {
         FetchResponse response = fetcher.fetchAsync(null).get();
         assertTrue(response.isFetched());
         assertEquals("fakeValue", response.entry().getConfig().getEntries().get("fakeKey").getSettingsValue().getStringValue());
+
+        fetcher.close();
+    }
+
+    private static Stream<Arguments> emptyFetchTestData() {
+        return Stream.of(
+                Arguments.of(""),
+                Arguments.of("null")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyFetchTestData")
+    public void fetchEmpty(String body) throws Exception {
+        this.server.enqueue(new MockResponse().setResponseCode(200).setBody(body));
+
+        ConfigFetcher fetcher = new ConfigFetcher(new OkHttpClient.Builder().build(),
+                logger,
+                "",
+                this.server.url("/").toString(),
+                false,
+                PollingModes.manualPoll().getPollingIdentifier());
+
+        FetchResponse response = fetcher.fetchAsync(null).get();
+        assertFalse(response.isFetched());
+        assertEquals("Fetching config JSON was successful but the HTTP response content was invalid.", response.error().toString());
 
         fetcher.close();
     }

--- a/src/test/java/com/configcat/LoggerTest.java
+++ b/src/test/java/com/configcat/LoggerTest.java
@@ -17,7 +17,7 @@ class LoggerTest {
         logger.error(1000, "error", new Exception());
 
         verify(mockLogger, times(1)).debug(anyString(), eq(0), eq("debug"));
-        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(Exception.class));
+        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(), any(Exception.class));
         verify(mockLogger, times(1)).warn(anyString(), eq(3000), eq("warn"));
         verify(mockLogger, times(1)).info(anyString(), eq(5000), eq("info"));
     }
@@ -33,7 +33,7 @@ class LoggerTest {
         logger.error(1000, "error", new Exception());
 
         verify(mockLogger, never()).debug(anyString(), eq(0), eq("debug"));
-        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(Exception.class));
+        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(), any(Exception.class));
         verify(mockLogger, times(1)).warn(anyString(), eq(3000), eq("warn"));
         verify(mockLogger, times(1)).info(anyString(), eq(5000), eq("info"));
     }
@@ -51,7 +51,7 @@ class LoggerTest {
         verify(mockLogger, never()).debug(anyString(), eq(0), eq("debug"));
         verify(mockLogger, never()).info(anyString(), eq(5000), eq("info"));
         verify(mockLogger, times(1)).warn(anyString(), eq(3000), eq("warn"));
-        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(Exception.class));
+        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(), any(Exception.class));
     }
 
     @Test
@@ -67,7 +67,7 @@ class LoggerTest {
         verify(mockLogger, never()).debug(anyString(), eq(0), eq("debug"));
         verify(mockLogger, never()).info(anyString(), eq(5000), eq("info"));
         verify(mockLogger, never()).warn(anyString(), eq(3000), eq("warn"));
-        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(Exception.class));
+        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(), any(Exception.class));
     }
 
     @Test
@@ -83,7 +83,7 @@ class LoggerTest {
         verify(mockLogger, never()).debug(anyString(), eq(0), eq("debug"));
         verify(mockLogger, never()).info(anyString(), eq(5000), eq("info"));
         verify(mockLogger, never()).warn(anyString(), eq(3000), eq("warn"));
-        verify(mockLogger, never()).error(anyString(), eq(1000), eq("error"), any(Exception.class));
+        verify(mockLogger, never()).error(anyString(), eq(1000), eq("error"), any(), any(Exception.class));
     }
 
     @Test
@@ -105,9 +105,9 @@ class LoggerTest {
         verify(mockLogger, never()).debug(anyString(), eq(0), eq("debug"));
         verify(mockLogger, times(1)).info(anyString(), eq(5000), eq("info"));
         verify(mockLogger, times(1)).warn(anyString(), eq(3000), eq("warn"));
-        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(Exception.class));
+        verify(mockLogger, times(1)).error(anyString(), eq(1000), eq("error"), any(), any(Exception.class));
         verify(mockLogger, never()).info(anyString(), eq(5001), eq("info"));
         verify(mockLogger, never()).warn(anyString(), eq(3001), eq("warn"));
-        verify(mockLogger, never()).error(anyString(), eq(1001), eq("error"), any(Exception.class));
+        verify(mockLogger, never()).error(anyString(), eq(1001), eq("error"), any(), any(Exception.class));
     }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

- In this PR we only consider the 200 HTTP status code as a successful fetch instead of the 200..299 range.
- We also fail early when we get an empty response body.
- All the other invalid JSON cases are checked during deserialization, where we throw an exception with Invalid config JSON content: <json-content> message.
- ConfigCatLogger.error(int eventId, Object message, Throwable exception) method extends the formatted message with the exception.getMessage value.

### Related issues (only if applicable)
- [Trello ticket](https://trello.com/c/uhARaUbh/450-nem-200-as-success-elfogad%C3%A1sa-potenci%C3%A1lisan-elcache-elt-invalid-config)

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
